### PR TITLE
Fix: owner info to name and version

### DIFF
--- a/src/main/kotlin/PluginMain.kt
+++ b/src/main/kotlin/PluginMain.kt
@@ -73,7 +73,7 @@ internal object PluginMain : KotlinPlugin(
             val owner = command?.owner
             val (logger, owned) = when (owner) {
                 is JvmPlugin -> owner.logger to ", command owned by ${owner.description.name} v${owner.description.version}"
-                else -> MiraiConsole.mainLogger to " "
+                else -> MiraiConsole.mainLogger to ", command owned by buildin"
             }
             val msg = tip + owned
 

--- a/src/main/kotlin/PluginMain.kt
+++ b/src/main/kotlin/PluginMain.kt
@@ -71,11 +71,11 @@ internal object PluginMain : KotlinPlugin(
     suspend fun handleCommand(sender: CommandSender, message: MessageChain) {
         suspend fun CommandExecuteResult.reminded(tip: String, reply: ReplyHelp) {
             val owner = command?.owner
-            val (logger, printOwner) = when (owner) {
-                is JvmPlugin -> owner.logger to true
-                else -> MiraiConsole.mainLogger to false
+            val (logger, owned) = when (owner) {
+                is JvmPlugin -> owner.logger to ", command owned by ${owner.description.name} v${owner.description.version}"
+                else -> MiraiConsole.mainLogger to " "
             }
-            val msg = tip + if (printOwner) ", command owned by $owner" else " "
+            val msg = tip + owned
 
             when (reply) {
                 ReplyHelp.CONSOLE -> {


### PR DESCRIPTION
突然想起来 owner info 优化成 `name` 和 `version` 会对用户友好一些

`command owned by xyz.cssxsh.mirai.pixiv.PixivHelperPlugin@74fc3fc7`
fix:
`command owned by pixiv-helper v2.0.0`